### PR TITLE
WIP: Making package setup.py installable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-#cvxopt
+cvxopt
 scikit-learn
 joblib
 #git clone git://git.tuebingen.mpg.de/libdai.git
-#git+git://github.com/amueller/pyqpbo.git#egg=pyqbo
-#git+git://github.com/amueller/daimrf.git#egg=daimrf
+git+git://github.com/amueller/pyqpbo.git#egg=pyqbo
+git+git://github.com/amueller/daimrf.git#egg=daimrf
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 
-setup(
+setup(name="pystruct",
+    version="0.0.1",
     cmdclass = {'build_ext': build_ext},
     ext_modules = [Extension("pystruct.models.utils", ["src/utils.pyx"])]
 )


### PR DESCRIPTION
This is a work-in-progress to get pystruct to be installable without too many headaches. I suspect that libdai and ad3 will go under extras for setup.py http://pythonhosted.org/distribute/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
