### PR TITLE
Begining of test for installation of inference methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
     - "2.7"
+virtualenv: 
+    system_site_packages: true
 before_install:
-    - deactivate
     - sudo apt-get update -qq
     - sudo apt-get install -qq python-scipy python-nose python-cvxopt python-sklearn
-    - virtualenv --system-site-packages ~/virtualenv/this
-    - source ~/virtualenv/this/bin/activate
-    - pip install cython --use-mirrors
-    - pip install git+git://github.com/amueller/pyqpbo.git#egg=pyqpbo
-    # Workaround for a permissions issue with Travis virtual machine images
-    # that breaks Python's multiprocessing:
-    # https://github.com/travis-ci/travis-cookbooks/issues/155
     - sudo rm -rf /dev/shm
     - sudo ln -s /run/shm /dev/shm 
-install: python setup.py build_ext --inplace
+install:
+    - pip install --use-mirrors -r requirements.txt
+    - python setup.py build_ext --inplace
 script: make test

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -1,0 +1,5 @@
+from pystruct.inference import get_installed
+
+def test_pyqpbo() :
+    import pyqpbo
+    assert 'qpbo' in get_installed()


### PR DESCRIPTION
These tests really should be a stopgap measure until we have confidence how to build these correctly, then we should let the failures of other unit tests let us know if something is wrong. 

I'm making this pull request early so I can trigger the travis-ci and see how things are going.
