### PR TITLE
Absolute URL for scikit-learn in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ might follow.
 The goal of PyStruct is to provide a well-documented tool for researchers as well as non-experts
 to make use of structured prediction algorithms.
 The design tries to stay as close as possible to the interface and conventions
-of [scikit-learn](scikit-learn.org).
+of [scikit-learn](http://scikit-learn.org).
 
 Currently the project is mostly maintained by Andreas Mueller, but contributions are very welcome.
 I plan a stable release soon.


### PR DESCRIPTION
It was showing up as https://github.com/pystruct/pystruct/blob/master/scikit-learn.org.
