### PR TITLE
MRG Cythonized loss-augmentation for CRFs

### DIFF
--- a/pystruct/inference/linear_programming.py
+++ b/pystruct/inference/linear_programming.py
@@ -73,7 +73,7 @@ def lp_general_graph(unaries, edges, edge_weights):
     # pairwise:
     repeated_pairwise = edge_weights.ravel()
     coef = np.hstack([coef, repeated_pairwise])
-    c = cvxopt.matrix(coef)
+    c = cvxopt.matrix(coef, tc='d')
     # for positivity inequalities
     G = cvxopt.spdiag(cvxopt.matrix(-np.ones(n_variables)))
     #G = cvxopt.matrix(-np.eye(n_variables))

--- a/pystruct/models/crf.py
+++ b/pystruct/models/crf.py
@@ -103,7 +103,7 @@ class CRF(StructuredModel):
         unary_potentials = self._get_unary_potentials(x, w)
         pairwise_potentials = self._get_pairwise_potentials(x, w)
         edges = self._get_edges(x)
-        loss_augment_unaries(unary_potentials, y, self.class_weight)
+        loss_augment_unaries(unary_potentials, np.asarray(y), self.class_weight)
 
         return inference_dispatch(unary_potentials, pairwise_potentials, edges,
                                   self.inference_method, relaxed=relaxed,

--- a/src/utils.pyx
+++ b/src/utils.pyx
@@ -23,4 +23,4 @@ def loss_augment_unaries(double[:,:] unary_potentials, some_int[:] y, double[:] 
        for s in range(n_states):
            if s == y[i]:
                continue
-           unary_potentials[i, s] += class_weight[s]
+           unary_potentials[i, s] += class_weight[y[i]]


### PR DESCRIPTION
This gets rid of some overhead in the CRF base class, that slows down learning when inference is very fast.
