### PR TITLE
opengm in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,19 @@ python:
 virtualenv:
     system_site_packages: true
 before_install:
+    - sudo add-apt-repository ppa:ukplc-team/testing -y
+    - sudo add-apt-repository ppa:cython-dev/master-ppa -y
     - sudo apt-get update -qq
-    - sudo apt-get install -qq python-scipy python-nose python-cvxopt python-sklearn libhdf5-serial-dev
-    - wget http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.bz2
-    - tar --bzip2 -xf boost_1_54_0.tar.bz2
-    - cd boost_1_54_0
-    - ./bootstrap.sh --help
-    - sudo ./bootstrap.sh --with-libraries=python
-    - sudo ./b2 -d0 install
-    - cd ..
+    - sudo apt-get install python-scipy python-cvxopt python-sklearn libhdf5-serial-dev libboost1.49-dev libboost-python1.49-dev cython
     - git clone https://github.com/opengm/opengm.git
     - cd opengm
-    - cmake . -DWITH_BOOST=TRUE -DWITH_HDF5=TRUE -DWITH_AD3=TRUE -DWITH_TRWS=TRUE -DWITH_QPBO=TRUE -DWITH_MRF=TRUE -DWITH_GCO=TRUE -DWITH_CONICBUNDLE=TRUE -DWITH_MAXFLOW=TRUE -DWITH_MAXFLOW_IBFS=TRUE -DBUILD_PYTHON_WRAPPER=TRUE -DBUILD_EXAMPLES=FALSE -DBUILD_TESTING=FALSE
-    - make externalLibs --quiet
-    - cmake . -DWITH_BOOST=TRUE -DWITH_HDF5=TRUE -DWITH_AD3=TRUE -DWITH_TRWS=TRUE -DWITH_QPBO=TRUE -DWITH_MRF=TRUE -DWITH_GCO=TRUE -DWITH_CONICBUNDLE=TRUE -DWITH_MAXFLOW=TRUE -DWITH_MAXFLOW_IBFS=TRUE -DBUILD_PYTHON_WRAPPER=TRUE -DBUILD_EXAMPLES=FALSE -DBUILD_TESTING=FALSE
-    - make --quiet
+    - cmake . -DWITH_BOOST=TRUE -DWITH_HDF5=TRUE -DBUILD_PYTHON_WRAPPER=TRUE -DBUILD_EXAMPLES=FALSE -DBUILD_TESTING=FALSE
+    - make -j6 --quiet
     - sudo make install
     - cd ..
     - sudo rm -rf /dev/shm
     - sudo ln -s /run/shm /dev/shm
 install:
-    - pip install --use-mirrors cython
     - pip install --use-mirrors -r requirements.txt
     - python setup.py build_ext --inplace
 script: make test


### PR DESCRIPTION
Travis now builds opengm. Unfortunately, this adds 10-15 minutes to build. We can shorten this time by
1. not using all of opengm external inference libraries
2. bundling opengm and getting it through apt-get
