### PR TITLE
MRG Remove redundant constraint in LP construction, get rid of GLPK

### DIFF
--- a/pystruct/tests/test_inference/test_exact_inference.py
+++ b/pystruct/tests/test_inference/test_exact_inference.py
@@ -8,17 +8,20 @@ def test_chain():
     # test LP, AD3, AD3-BB and JT on a chain.
     # they should all be exact
     rnd = np.random.RandomState(0)
-    algorithms = get_installed([('ad3', {'branch_and_bound':False}),
-                                ('ad3', {'branch_and_bound':True}),
-                                ('ogm', {'alg':'dyn'}),
-                                ('ogm', {'alg':'dd'}),
-                                ('ogm', {'alg':'trw'}),
-                                ('dai', {'alg':'jt'})])
+    algorithms = get_installed([('ad3', {'branch_and_bound': False}),
+                                ('ad3', {'branch_and_bound': True}),
+                                ('ogm', {'alg': 'dyn'}),
+                                ('ogm', {'alg': 'dd'}),
+                                ('ogm', {'alg': 'trw'}),
+                                ('dai', {'alg': 'jt'})])
+    n_states = 3
+    n_nodes = 10
+
     for i in xrange(10):
-        forward = np.c_[np.arange(9), np.arange(1, 10)]
-        backward = np.c_[np.arange(1, 10), np.arange(9)]
-        unary_potentials = rnd.normal(size=(10, 3))
-        pairwise_potentials = rnd.normal(size=(3, 3))
+        forward = np.c_[np.arange(n_nodes - 1), np.arange(1, n_nodes)]
+        backward = np.c_[np.arange(1, n_nodes), np.arange(n_nodes - 1)]
+        unary_potentials = rnd.normal(size=(n_nodes, n_states))
+        pairwise_potentials = rnd.normal(size=(n_states, n_states))
         # test that reversing edges is same as transposing pairwise potentials
         y_forward = inference_dispatch(unary_potentials, pairwise_potentials,
                                        forward, 'lp')


### PR DESCRIPTION
This PR removes the dependence on GLPK for linear programming inference.
This has been paining me a lot in the past. Reviews would be great.

This is one issue that users frequently ran into (most recently a JMLR reviewer).
This PR should greatly simplify installation for those systems where cvxopt does not come with glpk by default.

The basic issue was that the constraints need to be non-redundant for the cvxopt linear cone programming to work.
I naively wrote down the LP before, but one constraint per edge was redundant (that was not entirely clear to me before). So I just removed the redundant constraint and everything works :)
I didn't really bench the speed, but I don't think it is much different, and this inference method will never be fast anyhow.
