### PR TITLE
Primal objective in OneSlackSSVM

### DIFF
--- a/pystruct/learners/one_slack_ssvm.py
+++ b/pystruct/learners/one_slack_ssvm.py
@@ -479,7 +479,7 @@ class OneSlackSSVM(BaseSSVM):
                 # compute primal objective
                 last_slack = -np.dot(self.w, dpsi) + loss_mean
                 primal_objective = (self.C * len(X)
-                                    * np.max(last_slack, 0)
+                                    * max(last_slack, 0)
                                     + np.sum(self.w ** 2) / 2)
                 self.primal_objective_curve_.append(primal_objective)
                 self.cached_constraint_.append(cached_constraint)


### PR DESCRIPTION
`last_slack` is scalar, we should use `max` function here, not `np.max`
