### PR TITLE
Fix call to train_test_split in plot_latent_crf example.

### DIFF
--- a/examples/plot_latent_crf.py
+++ b/examples/plot_latent_crf.py
@@ -24,7 +24,8 @@ from pystruct.datasets import generate_crosses
 
 
 X, Y = generate_crosses(n_samples=20, noise=5, n_crosses=1, total_size=8)
-X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=.5)
+X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=.5,
+                                                    allow_nd=True)
 
 crf = LatentGridCRF(n_states_per_label=[1, 2])
 base_ssvm = OneSlackSSVM(model=crf, C=10., n_jobs=-1, inference_cache=20,


### PR DESCRIPTION
Scikit-learn's train_test_split changed its behaviour for nd samples in version 0.15.
