### PR TITLE
Implemented 'tree' and 'full' edge structure flags in MultiLabelClf

### DIFF
--- a/examples/multi_label.py
+++ b/examples/multi_label.py
@@ -25,25 +25,10 @@ from scipy import sparse
 
 from sklearn.metrics import hamming_loss
 from sklearn.datasets import fetch_mldata
-from sklearn.metrics import mutual_info_score
-from scipy.sparse.csgraph import minimum_spanning_tree
 
 from pystruct.learners import OneSlackSSVM
 from pystruct.models import MultiLabelClf
 from pystruct.datasets import load_scene
-
-
-def chow_liu_tree(y_):
-    # compute mutual information using sklearn
-    n_labels = y_.shape[1]
-    mi = np.zeros((n_labels, n_labels))
-    for i in range(n_labels):
-        for j in range(n_labels):
-            mi[i, j] = mutual_info_score(y_[:, i], y_[:, j])
-    mst = minimum_spanning_tree(sparse.csr_matrix(-mi))
-    edges = np.vstack(mst.nonzero()).T
-    edges.sort(axis=1)
-    return edges
 
 
 dataset = "scene"
@@ -64,13 +49,9 @@ else:
     X_train, X_test = scene['X_train'], scene['X_test']
     y_train, y_test = scene['y_train'], scene['y_test']
 
-n_labels = y_train.shape[1]
-full = np.vstack([x for x in itertools.combinations(range(n_labels), 2)])
-tree = chow_liu_tree(y_train)
-
-full_model = MultiLabelClf(edges=full, inference_method='qpbo')
+full_model = MultiLabelClf(edges="full", inference_method='qpbo')
 independent_model = MultiLabelClf(inference_method='unary')
-tree_model = MultiLabelClf(edges=tree, inference_method="max-product")
+tree_model = MultiLabelClf(edges="tree", inference_method="max-product")
 
 full_ssvm = OneSlackSSVM(full_model, inference_cache=50, C=.1, tol=0.01)
 

--- a/pystruct/models/multilabel_svm.py
+++ b/pystruct/models/multilabel_svm.py
@@ -1,5 +1,7 @@
+import itertools
 import numpy as np
 from .crf import CRF
+from ..utils import chow_liu_tree
 
 
 class MultiLabelClf(CRF):
@@ -42,11 +44,31 @@ class MultiLabelClf(CRF):
 
     def _set_size_joint_feature(self):
         # try to set the size of joint_feature if possible
-        if self.n_features is not None and self.n_states is not None:
-            if self.edges is None:
-                self.edges = np.zeros(shape=(0, 2), dtype=np.int)
+        self._set_edge_structure()
+        if isinstance(self.edges, np.ndarray) and self.n_features is not None \
+                and self.n_states is not None:
             self.size_joint_feature = (self.n_features * self.n_labels + 4 *
                                        self.edges.shape[0])
+
+    def _set_edge_structure(self):
+        # build an edge structure if edges is not already a custom structure
+        # only builds structures which do not require ground truth labels
+        if isinstance(self.edges, str):
+            if self.edges == 'full':
+                self.edges = np.vstack([x for x in
+                    itertools.combinations(range(self.n_labels), 2)])
+        # independent model
+        if self.edges is None:
+            self.edges = np.zeros(shape=(0, 2), dtype=np.int)
+
+    def _set_edge_structure_from_labels(self, Y):
+        # build an edge structure from the ground truth lables
+        self._set_edge_structure()
+        if isinstance(self.edges, str):
+            if self.edges == 'tree':
+                self.edges = chow_liu_tree(Y)
+            else:
+                raise ValueError("Unknown edge structure: %s" % self.edges)
 
     def initialize(self, X, Y):
         n_features = X.shape[1]
@@ -62,7 +84,8 @@ class MultiLabelClf(CRF):
         elif self.n_labels != n_labels:
             raise ValueError("Expected %d labels, got %d"
                              % (self.n_labels, n_labels))
-
+ 
+        self._set_edge_structure_from_labels(Y)
         self._set_size_joint_feature()
         self._set_class_weight()
 

--- a/pystruct/tests/test_utils/test_graph.py
+++ b/pystruct/tests/test_utils/test_graph.py
@@ -1,0 +1,21 @@
+import numpy as np
+from pystruct.utils.graph import chow_liu_tree
+from numpy.testing import assert_array_equal
+
+def test_chow_liu_tree_small():
+    # choose y so largest MI goes to (0, 1) and (1, 2) edges
+    y = np.array([[1, 0, 1], [0, 1, 1], [1, 0, 0], [1, 1, 1]])
+    edges_expected = np.array([[0, 1], [1, 2]])
+
+    edges = chow_liu_tree(y)
+    
+    assert_array_equal(edges, edges_expected)
+
+def test_chow_liu_tree_zero_mi():
+    # choose y so that MI is nonzero between (0, 1) and 0 between (1, 2)
+    y = np.array([[1, 0, 1], [0, 1, 1]])
+    edges_expected = np.array([[0, 1]])
+
+    edges = chow_liu_tree(y)
+    
+    assert_array_equal(edges, edges_expected)

--- a/pystruct/utils/__init__.py
+++ b/pystruct/utils/__init__.py
@@ -5,11 +5,11 @@ from .inference import (unwrap_pairwise, find_constraint,
                         exhaustive_inference, compress_sym, expand_sym)
 from .logging import SaveLogger
 from .plotting import plot_grid
-from .graph import make_grid_edges, edge_list_to_features
+from .graph import make_grid_edges, edge_list_to_features, chow_liu_tree
 
 __all__ = ["unwrap_pairwise",
            "make_grid_edges", "find_constraint",
            "find_constraint_latent", "inference", "loss_augmented_inference",
            "objective_primal", "exhaustive_loss_augmented_inference",
            "exhaustive_inference", "SaveLogger", "plot_grid", "compress_sym",
-           "expand_sym", "edge_list_to_features"]
+           "expand_sym", "edge_list_to_features", "chow_liu_tree"]

--- a/pystruct/utils/graph.py
+++ b/pystruct/utils/graph.py
@@ -1,4 +1,7 @@
 import numpy as np
+from scipy import sparse
+from sklearn.metrics import mutual_info_score
+from scipy.sparse.csgraph import minimum_spanning_tree
 
 
 def make_grid_edges(x, neighborhood=4, return_lists=False):
@@ -25,3 +28,16 @@ def edge_list_to_features(edge_list):
     edge_features[:len(edge_list[0]), 0] = 1
     edge_features[len(edge_list[0]):, 1] = 1
     return edge_features
+
+
+def chow_liu_tree(y_):
+    # compute mutual information using sklearn
+    n_labels = y_.shape[1]
+    mi = np.zeros((n_labels, n_labels))
+    for i in range(n_labels):
+        for j in range(n_labels):
+            mi[i, j] = mutual_info_score(y_[:, i], y_[:, j])
+    mst = minimum_spanning_tree(sparse.csr_matrix(-mi))
+    edges = np.vstack(mst.nonzero()).T
+    edges.sort(axis=1)
+    return edges


### PR DESCRIPTION
I have implemented the "tree" and "full" edge structures that were mentioned in the doc comments for `MultiLabelClf` but not previously implemented.  Most of the hard work was already done in the multi_label example, I just moved it into the library and added some test cases.

One thing that I have done that is perhaps a bit messy is to divide the code to set the edge structure into two methods one which does initialization when no labels are needed (edges is None or 'full') and another that needs the labels (edges is 'tree'). I did this because the existing multi label test cases run inference on the model without initializing. I'm not convinced this is the right approach.

Thoughts? Comments?