### PR TITLE
fixed GraphCRF._set_size_joint_feature

### DIFF
--- a/pystruct/models/graph_crf.py
+++ b/pystruct/models/graph_crf.py
@@ -101,7 +101,7 @@ class GraphCRF(CRF):
             else:
                 self.size_joint_feature = (
                     self.n_states * self.n_features
-                    + self.n_states * (self.n_states + 1) / 2)
+                    + self.n_states * (self.n_states + 1) // 2)
 
     def _get_edges(self, x):
         return x[1]


### PR DESCRIPTION
I fixed GraphCRF._set_size_joint_feature

The problem is that `size_joint_feature` set a float value for its shape.
For the details, please read this log.
```
python plot_grid_crf.py                                                                                              [17:09:30]
Traceback (most recent call last):
  File "plot_grid_crf.py", line 26, in <module>
    clf.fit(X, Y)
  File "/home/skarita/.pyenv/versions/pystruct/lib/python3.5/site-packages/pystruct-0.2.5-py3.5-linux-x86_64.egg/pystruct/learners/
one_slack_ssvm.py", line 409, in fit
    self.w = np.zeros(self.model.size_joint_feature)
TypeError: 'float' object cannot be interpreted as an integer

python svm_as_crf.py                                                                                                 [17:07:04]
/home/skarita/.pyenv/versions/pystruct/lib/python3.5/site-packages/sklearn/cross_validation.py:44: DeprecationWarning: This module 
was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved
. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)
Traceback (most recent call last):
  File "svm_as_crf.py", line 34, in <module>
    print(svm.model.size_joint_feature)
AttributeError: 'GraphCRF' object has no attribute 'size_joint_feature
```