### PR TITLE
Undirected crf graph: Use integer for size

### DIFF
--- a/pystruct/models/graph_crf.py
+++ b/pystruct/models/graph_crf.py
@@ -101,7 +101,7 @@ class GraphCRF(CRF):
             else:
                 self.size_joint_feature = (
                     self.n_states * self.n_features
-                    + self.n_states * (self.n_states + 1) / 2)
+                    + self.n_states * (self.n_states + 1) // 2)
 
     def _get_edges(self, x):
         return x[1]


### PR DESCRIPTION
With python3 the binary operator `/` means floating point division.
This commit switches the operator to `//`, which means integer
division in python2 as well as python3.