### PR TITLE
Fix joblib import

### DIFF
--- a/pystruct/utils/inference.py
+++ b/pystruct/utils/inference.py
@@ -1,5 +1,5 @@
 import itertools
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 import numpy as np
 


### PR DESCRIPTION
Import joblib from joblib rather than deprecated sklearn.externals.joblib